### PR TITLE
Build with Meson instead of hand-written install commands

### DIFF
--- a/io.github.mfat.sshpilot.yaml
+++ b/io.github.mfat.sshpilot.yaml
@@ -56,20 +56,9 @@ modules:
   - python3-deps.yml
 
   - name: sshpilot
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-build-isolation --no-deps --prefix=${FLATPAK_DEST} .
-      - install -Dm755 sshpilot-launcher.sh /app/bin/sshpilot
-      - install -Dm755 sshpilot-agent /app/bin/sshpilot-agent
-      - install -Dm644 sshpilot/resources/sshpilot.svg /app/share/icons/hicolor/scalable/apps/io.github.mfat.sshpilot.svg
-      - install -Dm644 io.github.mfat.sshpilot.desktop /app/share/applications/io.github.mfat.sshpilot.desktop
-      - install -Dm644 io.github.mfat.sshpilot.metainfo.xml /app/share/metainfo/io.github.mfat.sshpilot.metainfo.xml
+    buildsystem: meson
     sources:
       - type: git
         url: "https://github.com/mfat/sshpilot.git"
         #tag: v5.5.7
         commit: 97917355e7fb2254e4c38c694b48ce7b399e7090
-
-
-      - type: file
-        path: sshpilot-launcher.sh

--- a/io.github.mfat.sshpilot.yaml
+++ b/io.github.mfat.sshpilot.yaml
@@ -61,4 +61,4 @@ modules:
       - type: git
         url: "https://github.com/mfat/sshpilot.git"
         #tag: v5.5.7
-        commit: 97917355e7fb2254e4c38c694b48ce7b399e7090
+        commit: 9eb1ac919cda89f55c60374069d39636151cd728

--- a/sshpilot-launcher.sh
+++ b/sshpilot-launcher.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-export SSHPILOT_FLATPAK=1
-exec python3 -m sshpilot.main "$@"


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge until a release tag containing the Meson build exists.** The
> pinned `commit:` here is untouched (v5.5.7), which predates the Meson build —
> merging this before the next release bump would leave the manifest unbuildable.
> Merge it together with, or immediately after, the automated release bump.

## Why

Upstream restructured into the canonical GNOME layout (`src/`, `data/`, `po/`) and made Meson its build system. Every `install` command in this manifest addresses a file by hardcoded path, and all of them now point somewhere that no longer exists:

| build-command source | actual location upstream |
|---|---|
| `sshpilot/resources/sshpilot.svg` | `data/icons/hicolor/scalable/apps/io.github.mfat.sshpilot.svg` |
| `io.github.mfat.sshpilot.desktop` | `data/io.github.mfat.sshpilot.desktop.in` (translatable template) |
| `io.github.mfat.sshpilot.metainfo.xml` | `data/io.github.mfat.sshpilot.metainfo.xml.in` |

They also never compiled the Blueprint `.blp` sources — the app shipped whatever `.ui`/`.gresource` happened to be committed upstream.

## What changes

`buildsystem: meson` installs all of it: the `/app/bin/sshpilot` launcher, the Python package, the GResource compiled from `.blp` **inside the sandbox**, the desktop entry and metainfo merged from their `.in` templates, the icon, and `sshpilot-agent`. The paths come from the build system, so an upstream file move can no longer silently desync this manifest.

`sshpilot-launcher.sh` is removed — Meson generates the launcher. The only thing that script added was `SSHPILOT_FLATPAK=1`, which nothing reads: the app detects the sandbox via `FLATPAK_ID` / `/.flatpak-info`, and sets `SSHPILOT_FLATPAK` itself for terminal children.

Runtime Python deps still come from `python3-deps.yml`. `meson` and `blueprint-compiler` are both present in `org.gnome.Sdk 50`.

## Verified

Built locally with `flatpak-builder` against `org.gnome.Sdk 50`, with the source temporarily pinned to the upstream branch carrying the Meson build (`mfat/sshpilot@2eac077`). Build succeeded, and the resulting `files/` tree contains:

```
files/bin/sshpilot
files/bin/sshpilot-agent
files/share/io.github.mfat.sshpilot/io.github.mfat.sshpilot.gresource   (3.3M, compiled from .blp)
files/share/applications/io.github.mfat.sshpilot.desktop
files/share/metainfo/io.github.mfat.sshpilot.metainfo.xml
files/share/icons/hicolor/scalable/apps/io.github.mfat.sshpilot.svg
```

No `.blp` sources or example plugins are shipped. flatpak-builder exported the desktop entry, icon and metainfo as expected.